### PR TITLE
Enable audio playback if iOS is in silent mode

### DIFF
--- a/app/screens/player/player-screen.tsx
+++ b/app/screens/player/player-screen.tsx
@@ -53,6 +53,10 @@ export const PlayerScreen = observer(() => {
 
   const createAndLoadAndPlay = async () => {
     try {
+      // Make sure audio is played if iOS is in silent mode, defaults to `false`.
+      // NOTE: This sets the property globally which means _all_ future audio
+      // playbacks will be affected.
+      await Audio.setAudioModeAsync({ playsInSilentModeIOS: true })
       const { exists } = await FileSystem.getInfoAsync(fileUri)
       const uri = exists ? fileUri : webUri
       const { sound: newSound, status: newPlaybackStatus } = await Audio.Sound.createAsync(


### PR DESCRIPTION
By default `expo-av` doesn't playback sound on iOS if the device is set to
silent mode. We want to play audio even if the device is in silent mode,
though. That's the same behavior the Music, Podcast, Spotify etc. apps show.